### PR TITLE
feat: Add cache bust to action

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # salmon-sync
 
-This is a Github Action that syncs a folder to a Google Cloud bucket using `rclone`.
+This is a Github Action that syncs a folder to a Google Cloud bucket using `rclone` and then send an authenticated request to the doc site to invalidate the cache for the doc version.
 This action is only meant to work for Deephaven's documentation. It could be used in a more general purpose way to sync a folder into any Google cloud bucket (with the proper credentials), but that is subject to change and may break in any version.
 
 ## Parameters

--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ inputs:
     required: true
     type: string
     description: "The cache-bust token"
-  cache-bust-url:
+  docs-url:
     required: true
     type: string
-    description: "The cache-bust URL"
+    description: "The doc site URL"
 ```
 
 ## Example
@@ -47,5 +47,5 @@ Here is an example that syncs from the local path `temp/blog` to the blog sectio
     bucket: ${{ vars.DOCS_PROD_BUCKET }} # or ${{ vars.DOCS_PREVIEW_BUCKET }}
     credentials: ${{ secrets.DOCS_GOOGLE_CLOUD_CREDENTIALS }}
     cache-bust-token: ${{ secrets.DOCS_CACHE_BUST_TOKEN }}
-    cache-bust-url: ${{ vars.DOCS_PROD_CACHE_BUST_URL }} # or ${{ vars.DOCS_PREVIEW_CACHE_BUST_URL }}
+    docs-url: ${{ vars.DOCS_PROD_URL }} # or ${{ vars.DOCS_PREVIEW_URL }}
 ```

--- a/README.md
+++ b/README.md
@@ -4,40 +4,48 @@ This is a Github Action that syncs a folder to a Google Cloud bucket using `rclo
 This action is only meant to work for Deephaven's documentation. It could be used in a more general purpose way to sync a folder into any Google cloud bucket (with the proper credentials), but that is subject to change and may break in any version.
 
 ## Parameters
-```
+
+```yml
 inputs:
   source:
     required: true
     type: string
-    description: 'The source directory to sync.'
+    description: "The source directory to sync."
   destination:
     required: true
     type: string
-    description: 'The destination directory to sync. Relative to the bucket. It is recommended to use the GitHub repo path (such as deephaven/salmon-sync) as the minimum base to prevent collisions.'
-  project_number:
-    required: true
-    type: string
-    description: 'The Google Cloud project number.'
+    description: "The destination directory to sync. Relative to the bucket. It is recommended to use the GitHub repo path (such as deephaven/salmon-sync) as the minimum base to prevent collisions."
   bucket:
     required: true
     type: string
-    description: 'The Google Cloud bucket to sync to.'
+    description: "The Google Cloud bucket to sync to."
   credentials:
     required: true
     type: string
-    description: 'The Google Cloud credentials. Should be base64 encoded.'
+    description: "The Google Cloud credentials. Should be base64 encoded."
+  cache-bust-token:
+    required: true
+    type: string
+    description: "The cache-bust token"
+  cache-bust-url:
+    required: true
+    type: string
+    description: "The cache-bust URL"
 ```
 
 ## Example
+
 The action can be used as a step in a workflow
 Here is an example that syncs from the local path `temp/blog` to the blog section of the bucket.
-```
+
+```yml
 - name: Sync to the blog
   uses: deephaven/salmon-sync@v1
   with:
     source: temp/blog
     destination: deephaven/deephaven.io/blog
-    project_number: ${{ secrets.DOCS_GOOGLE_CLOUD_PROJECT_NUMBER}}
-    bucket: ${{ vars.DOCS_GOOGLE_CLOUD_BUCKET }}
+    bucket: ${{ vars.DOCS_GOOGLE_CLOUD_BUCKET }} # or ${{ vars.DOCS_PREVIEW_BUCKET }}
     credentials: ${{ secrets.DOCS_GOOGLE_CLOUD_CREDENTIALS }}
+    cache-bust-token: ${{ secrets.CACHE_BUST_TOKEN }}
+    cache-bust-url: ${{ vars.DOCS_PROD_CACHE_BUST_URL }} # or ${{ vars.DOCS_PREVIEW_CACHE_BUST_URL }}
 ```

--- a/README.md
+++ b/README.md
@@ -46,6 +46,6 @@ Here is an example that syncs from the local path `temp/blog` to the blog sectio
     destination: deephaven/deephaven.io/blog
     bucket: ${{ vars.DOCS_GOOGLE_CLOUD_BUCKET }} # or ${{ vars.DOCS_PREVIEW_BUCKET }}
     credentials: ${{ secrets.DOCS_GOOGLE_CLOUD_CREDENTIALS }}
-    cache-bust-token: ${{ secrets.CACHE_BUST_TOKEN }}
+    cache-bust-token: ${{ secrets.DOCS_CACHE_BUST_TOKEN }}
     cache-bust-url: ${{ vars.DOCS_PROD_CACHE_BUST_URL }} # or ${{ vars.DOCS_PREVIEW_CACHE_BUST_URL }}
 ```

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Here is an example that syncs from the local path `temp/blog` to the blog sectio
   with:
     source: temp/blog
     destination: deephaven/deephaven.io/blog
-    bucket: ${{ vars.DOCS_GOOGLE_CLOUD_BUCKET }} # or ${{ vars.DOCS_PREVIEW_BUCKET }}
+    bucket: ${{ vars.DOCS_PROD_BUCKET }} # or ${{ vars.DOCS_PREVIEW_BUCKET }}
     credentials: ${{ secrets.DOCS_GOOGLE_CLOUD_CREDENTIALS }}
     cache-bust-token: ${{ secrets.DOCS_CACHE_BUST_TOKEN }}
     cache-bust-url: ${{ vars.DOCS_PROD_CACHE_BUST_URL }} # or ${{ vars.DOCS_PREVIEW_CACHE_BUST_URL }}

--- a/action.yml
+++ b/action.yml
@@ -1,27 +1,31 @@
 name: Sync Salmon Directory
 description: Syncs a directory to a Google Cloud bucket using rclone.
-author: 'deephaven'
+author: "deephaven"
 inputs:
   source:
     required: true
     type: string
-    description: 'The source directory to sync.'
+    description: "The source directory to sync."
   destination:
     required: true
     type: string
-    description: 'The destination directory to sync. Relative to the bucket. It is recommended to use the GitHub repo path (such as deephaven/salmon-sync) as the minimum base to prevent collisions.'
-  project_number:
-    required: true
-    type: string
-    description: 'The Google Cloud project number.'
+    description: "The destination directory to sync. Relative to the bucket. It is recommended to use the GitHub repo path (such as deephaven/salmon-sync) as the minimum base to prevent collisions."
   bucket:
     required: true
     type: string
-    description: 'The Google Cloud bucket to sync to.'
+    description: "The Google Cloud bucket to sync to."
   credentials:
     required: true
     type: string
-    description: 'The Google Cloud credentials. Should be base64 encoded.'
+    description: "The Google Cloud credentials. Should be base64 encoded."
+  cache-bust-token:
+    required: true
+    type: string
+    description: "The cache-bust token"
+  cache-bust-url:
+    required: true
+    type: string
+    description: "The cache-bust URL"
 
 runs:
   using: "composite"
@@ -37,13 +41,22 @@ runs:
         echo $RCLONE_GCS_SERVICE_ACCOUNT_CREDENTIALS_ENCODED | base64 --decode > $HOME/credentials.json
       env:
         RCLONE_GCS_SERVICE_ACCOUNT_CREDENTIALS_ENCODED: ${{ inputs.credentials }}
-      
 
     - name: Sync source to destination
       shell: bash
       env:
         RCLONE_CONFIG_GCS_TYPE: "google cloud storage"
         RCLONE_GCS_SERVICE_ACCOUNT_FILE: $HOME/credentials.json
-        RCLONE_GCS_PROJECT_NUMBER: ${{ inputs.project_number }}
         RCLONE_GCS_BUCKET_POLICY_ONLY: "true"
       run: rclone sync ${{ inputs.source }} gcs:${{ inputs.bucket }}/${{ inputs.destination }}
+
+    - name: Bust cache
+      shell: bash
+      env:
+        CACHE_BUST_TOKEN: ${{ inputs.cache-bust-token }}
+      run: |
+        curl --fail-with-body --show-error --silent \
+          --request POST \
+          --header "authorization: Bearer $CACHE_BUST_TOKEN" \
+          --data "{ \"tags\": [ \"${{ inputs.destination }}\" ]}" \
+          --url ${{ inputs.cache-bust-url }}

--- a/action.yml
+++ b/action.yml
@@ -22,10 +22,10 @@ inputs:
     required: true
     type: string
     description: "The cache-bust token"
-  cache-bust-url:
+  docs-url:
     required: true
     type: string
-    description: "The cache-bust URL"
+    description: "The doc site URL"
 
 runs:
   using: "composite"
@@ -59,4 +59,4 @@ runs:
           --request POST \
           --header "authorization: Bearer $CACHE_BUST_TOKEN" \
           --data "{ \"tags\": [ \"${{ inputs.destination }}\" ]}" \
-          --url ${{ inputs.cache-bust-url }}
+          --url ${{ inputs.docs-url }}/api/cache-bust/


### PR DESCRIPTION
Adds cache busting after the assets have been uploaded. Right now just busts the whole destination path (which salmon has an open PR to bust based on bucket directory).

The cache bust URLs and secret will be added to our org

Also removes project_number which isn't actually needed to sync. With project_number, buckets will get created if the bucket is missing (or an empty string because I mistyped the env variable when I passed it in). Without project_number, the sync will fail instead of creating a bucket if the bucket/path doesn't exist on the remote.