### PR TITLE
Add copy-only flag for blog previews

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ inputs:
     default: "true"
     type: boolean
     description: "If true, the files will be marked as temporary and deleted after 14 days. Otherwise they will persist in S3 indefinitely."
+  copy-only:
+    required: false
+    default: "false"
+    type: boolean
+    description: "If true, uses rclone copy instead of sync. The files will be copied to the destination without affecting the existing files that do not exist in the source."
 ```
 
 ## Example

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,11 @@ inputs:
     default: "true"
     type: boolean
     description: "If true, the files will be marked as temporary and deleted after 14 days. Otherwise they will persist in S3 indefinitely."
+  copy-only:
+    required: false
+    default: "false"
+    type: boolean
+    description: "If true, uses rclone copy instead of sync. The files will be copied to the destination without affecting the existing files that do not exist in the source."
 
 runs:
   using: "composite"
@@ -49,4 +54,4 @@ runs:
       # Check temporary != 'false' so any other value is marked as temporary since there's no actual validation of boolean or required inputs
       # The production bucket doesn't have a lifecycle rule, so omitting temporary just results in a tag on files. They won't actually be deleted
       run: |
-        rclone sync --fast-list --checksum ${{ inputs.source }} :s3:${{ inputs.production == 'true' && 'deephaven-docs' || 'deephaven-docs-preview' }}/${{ inputs.destination }} ${{ inputs.temporary != 'false' && '--header-upload "x-amz-tagging: temporary=true"' || '' }}
+        rclone ${{ inputs.copy-only == 'true' && 'copy' || 'sync' }} --fast-list --checksum ${{ inputs.source }} :s3:${{ inputs.production == 'true' && 'deephaven-docs' || 'deephaven-docs-preview' }}/${{ inputs.destination }} ${{ inputs.temporary != 'false' && '--header-upload "x-amz-tagging: temporary=true"' || '' }}


### PR DESCRIPTION
Docs team mentioned they're seeing only 1 preview at a time which is intentional right now. Adding this `copy-only` flag so the action in the docs repo can use this for previews and have multiple blogs in preview at once. I'll adjust the preview action to link directly to the file instead of the blog overview page which will still only show the last pushed preview since the data file will overwrite the existing one still.